### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/security/api_key_security.py
+++ b/src/security/api_key_security.py
@@ -167,9 +167,9 @@ class APIKeySecurityManager:
         })
         
         if not is_valid:
-            logger.warning(f"API key validation failed: {masked_key} - Threats: {[t.value for t in threats]}")
+            logger.warning(f"API key validation failed: [KeyHash: {key_hash}] - Threats: {[t.value for t in threats]}")
         else:
-            logger.debug(f"API key validated successfully: {masked_key}")
+            logger.debug(f"API key validated successfully: [KeyHash: {key_hash}]")
         
         return key_info
     


### PR DESCRIPTION
Potential fix for [https://github.com/whisperengine-ai/whisperengine/security/code-scanning/3](https://github.com/whisperengine-ai/whisperengine/security/code-scanning/3)

The best approach is to eliminate all logging of API key fragments, even masked ones. Instead, log only non-sensitive representations, such as an irreversible hash of the API key.  
- **Edit**: In the logger.warning/debug statements within the `validate_api_key` method (lines 170, 172), replace the logging of `masked_key` with either an identifier (e.g., the hash, which is already computed at line 155 as `key_hash`) or a generic placeholder (e.g., `"[REDACTED]"`).  
- **Import**: No new imports are strictly required (hashlib and datetime are present).  
- **Methods/Definitions**: None required; the hash function exists as `self._hash_key(key)`.  
- **Lines to change**: Lines 170 and 172 in `src/security/api_key_security.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
