### PR TITLE
Potential fix for code scanning alert no. 53: Information exposure through an exception

### DIFF
--- a/src/web/voice_api.py
+++ b/src/web/voice_api.py
@@ -387,7 +387,7 @@ async def voice_health_check(
         logger.error("Voice health check failed: %s", e)
         return {
             "status": "unhealthy",
-            "error": str(e),
+            "error": "An internal error occurred.",
             "timestamp": datetime.now().isoformat()
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/whisperengine-ai/whisperengine/security/code-scanning/53](https://github.com/whisperengine-ai/whisperengine/security/code-scanning/53)

To fix this problem, we should avoid passing `str(e)` or `e` in any form directly to the user in API responses. Instead, log the exception and send a generic error message to the client. The exception's detailed information should only be retained in server logs.

**How to fix:**  
- In the exception block for the `/health` API, replace the `"error": str(e)` field with a generic message like `"error": "An internal error occurred."` (or similar).
- Ensure the exception is logged to retain the information for server operators.

**File/region to change:**  
- Only lines inside the `except` block of the `voice_health_check` method (lines 386-391) in `src/web/voice_api.py`.

**Needed:**  
- No new imports or methods are needed. Just modify the error response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
