### PR TITLE
Potential fix for code scanning alert no. 52: Information exposure through an exception

### DIFF
--- a/src/web/simple_chat_app.py
+++ b/src/web/simple_chat_app.py
@@ -801,8 +801,8 @@ class SimpleWebChatApp:
                     yield f"data: {json.dumps({'type': 'complete', 'full_response': full_response})}\n\n"
                     
                 except Exception as e:
-                    logger.error("Streaming chat message failed: %s", e)
-                    yield f"data: {json.dumps({'error': str(e)})}\n\n"
+                    logger.error("Streaming chat message failed: %s", e, exc_info=True)
+                    yield f"data: {json.dumps({'error': 'Internal server error'})}\n\n"
             
             return StreamingResponse(
                 generate_streaming_response(),


### PR DESCRIPTION
Potential fix for [https://github.com/whisperengine-ai/whisperengine/security/code-scanning/52](https://github.com/whisperengine-ai/whisperengine/security/code-scanning/52)

The best way to fix this problem is to avoid returning the exception’s message (or any part of the traceback or stack trace) to the user. Instead, log the full exception and/or stack trace on the server side using the `logger`, and send a generic error message to the user. This preserves useful debugging information while protecting sensitive details from end users. 

Change only the relevant lines inside `generate_streaming_response`, replacing `yield f"data: {{'error': str(e)}}\n\n"` with a yield of a generic error like `{"error": "Internal server error"}`, while keeping the existing logger call to record actual details for the operator.

Only src/web/simple_chat_app.py needs to be edited, within the shown code snippet. No new methods, definitions, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
